### PR TITLE
Made several changes to implement as 'more' discriminated union

### DIFF
--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -1,23 +1,27 @@
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.databind.ObjectMapper
 
-data class Payload(val message: String = "Hi mom")
-data class Error(val status: String = "LookingBad", val message: String = "hang it up")
 @JsonInclude(JsonInclude.Include.NON_NULL)
-data class UnionType(val payload: Payload? = null, val error: Error? = null)
+@JsonTypeInfo(use= JsonTypeInfo.Id.NAME, include= JsonTypeInfo.As.PROPERTY, property="type")
+@JsonSubTypes(JsonSubTypes.Type(value = UnionType.Payload::class, name = "payload"),  JsonSubTypes.Type(value = UnionType.Error::class, name = "error"))
+sealed class UnionType {
+    data class Payload(val message: String = "Hi mom"): UnionType()
+    data class Error(val status: String = "LookingBad", val message: String = "hang it up"): UnionType()
+}
 
 fun main() {
-    val successObject = Payload()
-    val errorObject = Error()
-    val successUnion = UnionType(payload = successObject)
-    val errorUnion = UnionType(error = errorObject)
+    val successObject = UnionType.Payload()
+    val errorObject = UnionType.Error()
+
     val mapper = ObjectMapper()
-    val successAsJson = mapper.writeValueAsString(successUnion)
-    val errorAsJson = mapper.writeValueAsString(errorUnion)
+    val successAsJson = mapper.writeValueAsString(successObject)
+    val errorAsJson = mapper.writeValueAsString(errorObject)
 
     println(successAsJson)
     println(errorAsJson)
 
     val reconstitutedSuccess = mapper.readValue<UnionType>(successAsJson, UnionType::class.java)
-    println("reconstitution successful: " + (reconstitutedSuccess == successUnion))
+    println("reconstitution successful: " + (reconstitutedSuccess == successObject))
 }


### PR DESCRIPTION
- Changed UnionType to be sealed class. Prevents both payload and error being filled in at the same time.
- Moved Payload and Error to be members of new sealed UnionType
- Added jackson annotations to auto-magically include string based 'type' attribute in json-ized string (works for parsing too)